### PR TITLE
Upgrade dependencies (springboot + jackson databind)

### DIFF
--- a/oidc-playground-server/pom.xml
+++ b/oidc-playground-server/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.5.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Upgrade these dependencies and reduce the number of CVE's from 14 to 1.
Run `mvn org.owasp:dependency-check-maven:5.1.0:check` from directory `oidc-playground-server` for comparison. You can find a report in `target/dependency-check-report.html`