### PR TITLE
add heartbeat logger

### DIFF
--- a/oidc-playground-server/src/main/java/playground/PlaygroundServerApplication.java
+++ b/oidc-playground-server/src/main/java/playground/PlaygroundServerApplication.java
@@ -10,6 +10,7 @@ import org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceAutoCo
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import playground.api.ACR;
 
 @SpringBootApplication(exclude = {AuditAutoConfiguration.class, HttpTraceAutoConfiguration.class,
@@ -17,6 +18,7 @@ import playground.api.ACR;
         JvmMetricsAutoConfiguration.class, MetricsAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class,
 })
 @EnableConfigurationProperties(ACR.class)
+@EnableScheduling
 public class PlaygroundServerApplication {
 
     public static void main(String[] args) {

--- a/oidc-playground-server/src/main/java/playground/heartbeat/HeartbeatLogger.java
+++ b/oidc-playground-server/src/main/java/playground/heartbeat/HeartbeatLogger.java
@@ -1,0 +1,16 @@
+package playground.heartbeat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeartbeatLogger {
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatLogger.class);
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void mark() {
+        LOG.info("MARK");
+    }
+}

--- a/oidc-playground-server/src/test/java/playground/heartbeat/HeartbeatLoggerTest.java
+++ b/oidc-playground-server/src/test/java/playground/heartbeat/HeartbeatLoggerTest.java
@@ -1,0 +1,33 @@
+package playground.heartbeat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class HeartbeatLoggerTest {
+
+    @Test
+    public void emitsMarkAtInfo() {
+        Logger logger = (Logger) LoggerFactory.getLogger(HeartbeatLogger.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            new HeartbeatLogger().mark();
+
+            List<ILoggingEvent> events = appender.list;
+            assertEquals(1, events.size());
+            assertEquals(Level.INFO, events.getFirst().getLevel());
+            assertEquals("MARK", events.getFirst().getFormattedMessage());
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+}


### PR DESCRIPTION
OIDC_playground (vooral op test en acc) wordt niet zo veel gebruikt.  Dan wordt er dus ook niks gelogd, maar van lege logs gaan alarmen af.  Deze PR (met dank aan Claude) voegt elk uur een heartbeat toe.

Als we dit generieker kunnen doen zodat we dit in al onze java projecten zouden kunnen opnemen, dan zou dat nog beter zijn natuurlijk!